### PR TITLE
Fix balance counter issue

### DIFF
--- a/src/components/TokenDisplay.tsx
+++ b/src/components/TokenDisplay.tsx
@@ -15,63 +15,65 @@ export default function TokenDisplay({ provider, nftId }) {
     const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
 
     useEffect(() => {
-        let intervalId
-        let lastUpdateTime = Date.now()
+        let intervalId;
+        let lastUpdateTime = Date.now();
 
         const fetchTokenBalance = async () => {
-            const abi = ["function balanceOf(address account) view returns (uint256)", "function TOKEN_EMISSION_RATE() view returns (uint256)"]
-            const contract = new ethers.Contract(config.chains[chainId].tokenContractAddress, abi, provider)
+            const abi = ["function balanceOf(address account) view returns (uint256)", "function TOKEN_EMISSION_RATE() view returns (uint256)"];
+            const contract = new ethers.Contract(config.chains[chainId].tokenContractAddress, abi, provider);
 
-            // If the nftId is 0 or null, the connectedWalletAddress does not have an NFT, so return early
+            // If the nftId is 0 or null, the connectedWalletAddress does not have an NFT, so return early and reset tokenBalance
             if (!nftId) {
-                setTokenBalance(0)
-                return
+                setTokenBalance(0);
+                return;
             }
 
             try {
-                // If the balance returns an error, return early
-                let balance
+                let balance;
                 try {
-                    balance = await contract.balanceOf(connectedWalletAddress)
+                    balance = await contract.balanceOf(connectedWalletAddress);
                 } catch (error) {
-                    return
+                    return;
                 }
 
-                const formattedBalance = Number(new BigNumber(balance).shiftedBy(-18))
+                const formattedBalance = Number(new BigNumber(balance).shiftedBy(-18));
+                const tokenEmissionRate = await contract.TOKEN_EMISSION_RATE();
+                const formattedTokenEmissionRate = Number(new BigNumber(tokenEmissionRate).shiftedBy(-18));
 
-                const tokenEmissionRate = await contract.TOKEN_EMISSION_RATE()
-                const formattedTokenEmissionRate = Number(new BigNumber(tokenEmissionRate).shiftedBy(-18))
+                setTokenBalance(formattedBalance);
+                lastUpdateTime = Date.now(); // Reset time
 
-                setTokenBalance(formattedBalance)
+                // Start the interval only if there is a valid balance and nftId
+                if (formattedBalance > 0) {
+                    intervalId = setInterval(() => {
+                        const now = Date.now();
+                        const elapsedSeconds = (now - lastUpdateTime) / 1000;
+                        lastUpdateTime = now;
 
-                // Start the interval (20ms) after fetching the initial balance
-                intervalId = setInterval(() => {
-                    const now = Date.now()
-                    const elapsedSeconds = (now - lastUpdateTime) / 1000
-                    lastUpdateTime = now
+                        // Increment the token balance based on the elapsed time
+                        setTokenBalance((prevBalance) => prevBalance + formattedTokenEmissionRate * elapsedSeconds);
+                    }, 20);
+                }
 
-                    // If an nftId exists increment the token balance by 1/50th of the token emission rate
-                    // so the token balance increases by the formattedTokenEmissionRate every second
-                    if (nftId) {
-                        setTokenBalance((prevBalance) => prevBalance + formattedTokenEmissionRate * elapsedSeconds)
-                    }
-                }, 20)
             } catch (error) {
-                console.error("Error fetching token balance:", error)
+                console.error("Error fetching token balance:", error);
             }
-        }
+        };
 
-        fetchTokenBalance()
+        fetchTokenBalance();
 
-        // Cleanup the interval on component unmount
-        return () => clearInterval(intervalId)
-    }, [provider, connectedWalletAddress, nftId, chainId])
+        // Clear the interval and reset balance when switching wallets or on unmount
+        return () => {
+            clearInterval(intervalId);
+            setTokenBalance(0); // Reset token balance when the component is cleaned up
+        };
+    }, [provider, connectedWalletAddress, nftId, chainId]);
 
     const addTokenToMetaMask = async () => {
-        const tokenAddress = config.chains[chainId].tokenContractAddress
-        const tokenSymbol = "SETTLER"
-        const tokenDecimals = 18
-        const tokenImage = config.localNftImage
+        const tokenAddress = config.chains[chainId].tokenContractAddress;
+        const tokenSymbol = "SETTLER";
+        const tokenDecimals = 18;
+        const tokenImage = config.localNftImage;
 
         try {
             if (window.ethereum) {
@@ -86,10 +88,10 @@ export default function TokenDisplay({ provider, nftId }) {
                             image: tokenImage,
                         },
                     },
-                })
+                });
             }
         } catch (error) {
-            console.error("Error adding token to MetaMask:", error)
+            console.error("Error adding token to MetaMask:", error);
         }
     }
 
@@ -128,5 +130,5 @@ export default function TokenDisplay({ provider, nftId }) {
             </HStack>
             <Text>Get 1 SETTLER token per second holding a SETTLEMENT NFT</Text>
         </VStack>
-    )
+    );
 }

--- a/src/components/TokenDisplay.tsx
+++ b/src/components/TokenDisplay.tsx
@@ -15,65 +15,65 @@ export default function TokenDisplay({ provider, nftId }) {
     const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
 
     useEffect(() => {
-        let intervalId;
-        let lastUpdateTime = Date.now();
+        let intervalId
+        let lastUpdateTime = Date.now()
 
         const fetchTokenBalance = async () => {
-            const abi = ["function balanceOf(address account) view returns (uint256)", "function TOKEN_EMISSION_RATE() view returns (uint256)"];
-            const contract = new ethers.Contract(config.chains[chainId].tokenContractAddress, abi, provider);
+            const abi = ["function balanceOf(address account) view returns (uint256)", "function TOKEN_EMISSION_RATE() view returns (uint256)"]
+            const contract = new ethers.Contract(config.chains[chainId].tokenContractAddress, abi, provider)
 
             // If the nftId is 0 or null, the connectedWalletAddress does not have an NFT, so return early and reset tokenBalance
             if (!nftId) {
-                setTokenBalance(0);
-                return;
+                setTokenBalance(0)
+                return
             }
 
             try {
-                let balance;
+                // If the balance returns an error, return early
+                let balance
                 try {
-                    balance = await contract.balanceOf(connectedWalletAddress);
+                    balance = await contract.balanceOf(connectedWalletAddress)
                 } catch (error) {
-                    return;
+                    return
                 }
 
-                const formattedBalance = Number(new BigNumber(balance).shiftedBy(-18));
-                const tokenEmissionRate = await contract.TOKEN_EMISSION_RATE();
-                const formattedTokenEmissionRate = Number(new BigNumber(tokenEmissionRate).shiftedBy(-18));
+                const formattedBalance = Number(new BigNumber(balance).shiftedBy(-18))
+                const tokenEmissionRate = await contract.TOKEN_EMISSION_RATE()
+                const formattedTokenEmissionRate = Number(new BigNumber(tokenEmissionRate).shiftedBy(-18))
 
-                setTokenBalance(formattedBalance);
-                lastUpdateTime = Date.now(); // Reset time
+                setTokenBalance(formattedBalance)
+                lastUpdateTime = Date.now() // Reset time
 
                 // Start the interval only if there is a valid balance and nftId
                 if (formattedBalance > 0) {
                     intervalId = setInterval(() => {
-                        const now = Date.now();
-                        const elapsedSeconds = (now - lastUpdateTime) / 1000;
-                        lastUpdateTime = now;
+                        const now = Date.now()
+                        const elapsedSeconds = (now - lastUpdateTime) / 1000
+                        lastUpdateTime = now
 
                         // Increment the token balance based on the elapsed time
-                        setTokenBalance((prevBalance) => prevBalance + formattedTokenEmissionRate * elapsedSeconds);
-                    }, 20);
+                        setTokenBalance((prevBalance) => prevBalance + formattedTokenEmissionRate * elapsedSeconds)
+                    }, 20)
                 }
-
             } catch (error) {
-                console.error("Error fetching token balance:", error);
+                console.error("Error fetching token balance:", error)
             }
-        };
+        }
 
-        fetchTokenBalance();
+        fetchTokenBalance()
 
         // Clear the interval and reset balance when switching wallets or on unmount
         return () => {
-            clearInterval(intervalId);
-            setTokenBalance(0); // Reset token balance when the component is cleaned up
-        };
-    }, [provider, connectedWalletAddress, nftId, chainId]);
+            clearInterval(intervalId)
+            setTokenBalance(0) // Reset token balance when the component is cleaned up
+        }
+    }, [provider, connectedWalletAddress, nftId, chainId])
 
     const addTokenToMetaMask = async () => {
-        const tokenAddress = config.chains[chainId].tokenContractAddress;
-        const tokenSymbol = "SETTLER";
-        const tokenDecimals = 18;
-        const tokenImage = config.localNftImage;
+        const tokenAddress = config.chains[chainId].tokenContractAddress
+        const tokenSymbol = "SETTLER"
+        const tokenDecimals = 18
+        const tokenImage = config.localNftImage
 
         try {
             if (window.ethereum) {
@@ -88,10 +88,10 @@ export default function TokenDisplay({ provider, nftId }) {
                             image: tokenImage,
                         },
                     },
-                });
+                })
             }
         } catch (error) {
-            console.error("Error adding token to MetaMask:", error);
+            console.error("Error adding token to MetaMask:", error)
         }
     }
 
@@ -130,5 +130,5 @@ export default function TokenDisplay({ provider, nftId }) {
             </HStack>
             <Text>Get 1 SETTLER token per second holding a SETTLEMENT NFT</Text>
         </VStack>
-    );
+    )
 }


### PR DESCRIPTION
When connecting a wallet that does not hold the Settler NFT, the token counter correctly indicates a balance of 0 and does not increase. 

However, when switching wallets, the balance counter starts increasing even when connecting a wallet that does not hold the NFT. 

This PR fixes this issue by doing the following: 

1. Clear the interval every time the connected wallet changes.
2. Re-fetch the NFT balance and reset the counter when switching wallets.
3. Check the balance of the current connected wallet more robustly within the interval logic.